### PR TITLE
Fix long file paths on Windows

### DIFF
--- a/src/ddmd/access.d
+++ b/src/ddmd/access.d
@@ -31,7 +31,7 @@ private enum LOG = false;
 /****************************************
  * Return Prot access for Dsymbol smember in this declaration.
  */
-extern (C++) Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
+private Prot getAccess(AggregateDeclaration ad, Dsymbol smember)
 {
     Prot access_ret = Prot(PROTnone);
     static if (LOG)
@@ -203,7 +203,7 @@ extern (C++) bool checkAccess(AggregateDeclaration ad, Loc loc, Scope* sc, Dsymb
 /****************************************
  * Determine if this is the same or friend of cd.
  */
-extern (C++) bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
+private bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
 {
     static if (LOG)
     {
@@ -231,7 +231,7 @@ extern (C++) bool isFriendOf(AggregateDeclaration ad, AggregateDeclaration cd)
 /****************************************
  * Determine if scope sc has package level access to s.
  */
-extern (C++) bool hasPackageAccess(Scope* sc, Dsymbol s)
+private bool hasPackageAccess(Scope* sc, Dsymbol s)
 {
     return hasPackageAccess(sc._module, s);
 }
@@ -313,7 +313,7 @@ extern (C++) bool hasPackageAccess(Module mod, Dsymbol s)
 /****************************************
  * Determine if scope sc has protected level access to cd.
  */
-bool hasProtectedAccess(Scope *sc, Dsymbol s)
+private bool hasProtectedAccess(Scope *sc, Dsymbol s)
 {
     if (auto cd = s.isClassMember()) // also includes interfaces
     {
@@ -332,7 +332,7 @@ bool hasProtectedAccess(Scope *sc, Dsymbol s)
 /**********************************
  * Determine if smember has access to private members of this declaration.
  */
-extern (C++) bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
+private bool hasPrivateAccess(AggregateDeclaration ad, Dsymbol smember)
 {
     if (smember)
     {

--- a/src/ddmd/apply.d
+++ b/src/ddmd/apply.d
@@ -27,7 +27,7 @@ import ddmd.visitor;
  * It's a bit slower than using virtual functions, but more encapsulated and less brittle.
  * Creating an iterator for this would be much more complex.
  */
-extern (C++) final class PostorderExpressionVisitor : StoppableVisitor
+private extern (C++) final class PostorderExpressionVisitor : StoppableVisitor
 {
     alias visit = super.visit;
 public:

--- a/src/ddmd/attrib.d
+++ b/src/ddmd/attrib.d
@@ -1330,24 +1330,3 @@ extern (C++) final class UserAttributeDeclaration : AttribDeclaration
         v.visit(this);
     }
 }
-
-uint setMangleOverride(Dsymbol s, char* sym)
-{
-    AttribDeclaration ad = s.isAttribDeclaration();
-    if (ad)
-    {
-        Dsymbols* decls = ad.include(null, null);
-        uint nestedCount = 0;
-        if (decls && decls.dim)
-            for (size_t i = 0; i < decls.dim; ++i)
-                nestedCount += setMangleOverride((*decls)[i], sym);
-        return nestedCount;
-    }
-    else if (s.isFuncDeclaration() || s.isVarDeclaration())
-    {
-        s.isDeclaration().mangleOverride = sym;
-        return 1;
-    }
-    else
-        return 0;
-}

--- a/src/ddmd/backend/mscoffobj.c
+++ b/src/ddmd/backend/mscoffobj.c
@@ -338,6 +338,7 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
 
     segidx_pdata = UNKNOWN;
     segidx_xdata = UNKNOWN;
+    segidx_debugS = UNKNOWN;
 
     // Initialize buffers
 
@@ -381,10 +382,6 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
 
     int alignText = I64 ? IMAGE_SCN_ALIGN_16BYTES : IMAGE_SCN_ALIGN_8BYTES;
     int alignData = IMAGE_SCN_ALIGN_16BYTES;
-    addScnhdr(".debug$S", IMAGE_SCN_CNT_INITIALIZED_DATA |
-                          IMAGE_SCN_ALIGN_1BYTES |
-                          IMAGE_SCN_MEM_READ |
-                          IMAGE_SCN_MEM_DISCARDABLE);
     addScnhdr(".data$B",  IMAGE_SCN_CNT_INITIALIZED_DATA |
                           alignData |
                           IMAGE_SCN_MEM_READ |
@@ -403,11 +400,10 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
 
     seg_count = 0;
 
-#define SHI_DEBUGS      1
-#define SHI_DATA        2
-#define SHI_TEXT        3
-#define SHI_UDATA       4
-#define SHI_CDATA       5
+#define SHI_DATA        1
+#define SHI_TEXT        2
+#define SHI_UDATA       3
+#define SHI_CDATA       4
 
     getsegment2(SHI_TEXT);
     assert(SegData[CODE]->SDseg == CODE);
@@ -420,8 +416,6 @@ MsCoffObj *MsCoffObj::init(Outbuffer *objbuf, const char *filename, const char *
 
     getsegment2(SHI_UDATA);
     assert(SegData[UDATA]->SDseg == UDATA);
-
-    segidx_debugS  = getsegment2(SHI_DEBUGS);
 
     if (config.fulltypes)
         cv8_initfile(filename);
@@ -1631,7 +1625,13 @@ segidx_t MsCoffObj::seg_xdata_comdat(symbol *sfunc)
 
 segidx_t MsCoffObj::seg_debugS()
 {
-    // Probably should generate this lazilly, too.
+    if (segidx_debugS == UNKNOWN)
+    {
+        segidx_debugS = MsCoffObj::getsegment(".debug$S", IMAGE_SCN_CNT_INITIALIZED_DATA |
+                                          IMAGE_SCN_ALIGN_1BYTES |
+                                          IMAGE_SCN_MEM_READ |
+                                          IMAGE_SCN_MEM_DISCARDABLE);
+    }
     return segidx_debugS;
 }
 

--- a/src/ddmd/canthrow.d
+++ b/src/ddmd/canthrow.d
@@ -234,7 +234,7 @@ extern (C++) bool canThrow(Expression e, FuncDeclaration func, bool mustNotThrow
  * Does symbol, when initialized, throw?
  * Mirrors logic in Dsymbol_toElem().
  */
-extern (C++) bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow)
+private bool Dsymbol_canThrow(Dsymbol s, FuncDeclaration func, bool mustNotThrow)
 {
     AttribDeclaration ad;
     VarDeclaration vd;

--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -393,7 +393,7 @@ Lneed:
 /*******************************************
  * Check given aggregate actually has an identity opEquals or not.
  */
-private extern (C++) FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
+private FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
 {
     Dsymbol eq = search_function(ad, Id.eq);
     if (eq)

--- a/src/ddmd/clone.d
+++ b/src/ddmd/clone.d
@@ -393,7 +393,7 @@ Lneed:
 /*******************************************
  * Check given aggregate actually has an identity opEquals or not.
  */
-extern (C++) FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
+private extern (C++) FuncDeclaration hasIdentityOpEquals(AggregateDeclaration ad, Scope* sc)
 {
     Dsymbol eq = search_function(ad, Id.eq);
     if (eq)

--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -33,7 +33,7 @@ import ddmd.utf;
 
 private enum LOG = false;
 
-extern (C++) Expression expType(Type type, Expression e)
+private Expression expType(Type type, Expression e)
 {
     if (type != e.type)
     {
@@ -107,7 +107,7 @@ extern (C++) UnionExp Not(Type type, Expression e1)
     return ue;
 }
 
-extern (C++) UnionExp Bool(Type type, Expression e1)
+private extern (C++) UnionExp Bool(Type type, Expression e1)
 {
     UnionExp ue;
     Loc loc = e1.loc;

--- a/src/ddmd/constfold.d
+++ b/src/ddmd/constfold.d
@@ -107,7 +107,7 @@ extern (C++) UnionExp Not(Type type, Expression e1)
     return ue;
 }
 
-private extern (C++) UnionExp Bool(Type type, Expression e1)
+private UnionExp Bool(Type type, Expression e1)
 {
     UnionExp ue;
     Loc loc = e1.loc;

--- a/src/ddmd/dsymbolsem.d
+++ b/src/ddmd/dsymbolsem.d
@@ -72,6 +72,27 @@ import ddmd.visitor;
 
 enum LOG = false;
 
+private uint setMangleOverride(Dsymbol s, char* sym)
+{
+    AttribDeclaration ad = s.isAttribDeclaration();
+    if (ad)
+    {
+        Dsymbols* decls = ad.include(null, null);
+        uint nestedCount = 0;
+        if (decls && decls.dim)
+            for (size_t i = 0; i < decls.dim; ++i)
+                nestedCount += setMangleOverride((*decls)[i], sym);
+        return nestedCount;
+    }
+    else if (s.isFuncDeclaration() || s.isVarDeclaration())
+    {
+        s.isDeclaration().mangleOverride = sym;
+        return 1;
+    }
+    else
+        return 0;
+}
+
 /*************************************
  * Does semantic analysis on the public face of declarations.
  */

--- a/src/ddmd/json.d
+++ b/src/ddmd/json.d
@@ -563,6 +563,12 @@ public:
         {
             visit(cast(AttribDeclaration)d);
         }
+        Dsymbols* ds = d.decl ? d.decl : d.elsedecl;
+        for (size_t i = 0; i < ds.dim; i++)
+        {
+            Dsymbol s = (*ds)[i];
+            s.accept(this);
+        }
     }
 
     override void visit(TypeInfoDeclaration d)

--- a/src/ddmd/root/file.d
+++ b/src/ddmd/root/file.d
@@ -260,7 +260,7 @@ nothrow:
             const(char)* name = this.name.toChars();
             // work around Windows file path length limitation
             // (see documentation for toExtendedLengthPath).
-            wchar[1024] buf;
+            wchar[2048] buf;
             const extendedPath = name.toExtendedLengthPath(buf);
             HANDLE h = CreateFileW(&extendedPath[0],
                                    GENERIC_WRITE,

--- a/src/ddmd/root/file.d
+++ b/src/ddmd/root/file.d
@@ -256,7 +256,12 @@ nothrow:
         {
             DWORD numwritten;
             const(char)* name = this.name.toChars();
-            HANDLE h = CreateFileA(name, GENERIC_WRITE, 0, null, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, null);
+            HANDLE h = CreateFileW(&name.toExtendedLengthPath[0],
+                                   GENERIC_WRITE,
+                                   0,
+                                   null,
+                                   CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+                                   null);
             if (h == INVALID_HANDLE_VALUE)
                 goto err;
             if (WriteFile(h, buffer, cast(DWORD)len, &numwritten, null) != TRUE)

--- a/src/ddmd/root/file.d
+++ b/src/ddmd/root/file.d
@@ -254,21 +254,20 @@ nothrow:
         }
         else version (Windows)
         {
-            import ddmd.root.filename: toExtendedLengthPath;
+            import ddmd.root.filename: extendedPathThen;
 
             DWORD numwritten; // here because of the gotos
             const(char)* name = this.name.toChars();
             // work around Windows file path length limitation
-            // (see documentation for toExtendedLengthPath).
-            wchar[2048] buf;
-            const extendedPath = name.toExtendedLengthPath(buf);
-            HANDLE h = CreateFileW(&extendedPath[0],
-                                   GENERIC_WRITE,
-                                   0,
-                                   null,
-                                   CREATE_ALWAYS,
-                                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
-                                   null);
+            // (see documentation for extendedPathThen).
+            HANDLE h = name.extendedPathThen!
+                (p => CreateFileW(&p[0],
+                                  GENERIC_WRITE,
+                                  0,
+                                  null,
+                                  CREATE_ALWAYS,
+                                  FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+                                  null));
             if (h == INVALID_HANDLE_VALUE)
                 goto err;
 

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -748,10 +748,8 @@ version(Windows)
         import core.sys.windows.winerror: ERROR_ALREADY_EXISTS;
         import core.stdc.errno: errno, EEXIST;
 
-        wchar[2048] buf;
-        const extendedPath = path.toExtendedLengthPath(buf);
-
-        const createRet = CreateDirectoryW(&extendedPath[0], null /*securityAttributes*/);
+        const createRet = path.extendedPathThen!(p => CreateDirectoryW(&p[0],
+                                                                       null /*securityAttributes*/));
         const lastError = GetLastError();
 
         // Preserve compatibility with mkdir since the calling code expects
@@ -765,58 +763,17 @@ version(Windows)
 
     // Converts a path to one suitable to be passed to Win32 API
     // functions that can deal with paths longer than 248
-    // characters. For more information:
+    // characters then calls the supplied function on it.
+    // For more information:
     // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
-    // buf is used as a scratch space instead of allocating. If its length is insufficient,
-    // memory is allocated on the GC heap.
-    package wchar[] toExtendedLengthPath(const(char*) path, wchar[] buf = []) nothrow
+    package auto extendedPathThen(alias F)(const(char*) path)
     {
         import core.sys.windows.winbase: GetFullPathNameW;
 
+        wchar[1024] wpathBuf;
         // Since the unicode Win32 APIs use UTF16, we need to convert
         // from UTF8 to UTF16 first.
-        const wpath = path.toWStringz(buf);
-
-        // Now wpath is the UTF16 version of path, but to be able to use
-        // extended paths, we need to prefix with `\\?\` and the absolute
-        // path.
-        static immutable prefix = `\\?\`w;
-
-        // We don't know how large the absolute file path will be We
-        // need to tell GetFullPathNameW the size of the buffer we're
-        // passing in so we defensively allocate 4 times the size of
-        // the string we have currently.
-        const absLength = prefix.length + wpath.length * 4;
-
-        // We now need a buffer `absLength` long. We try to reuse buf if there's
-        // enough space left. If not, allocate.
-        static wchar[1024] absBuf;
-        auto absPath = absLength > absBuf.length ? new wchar[absLength] : absBuf[];
-
-        absPath[0 .. prefix.length] = prefix[];
-
-        const absPathRet = GetFullPathNameW(&wpath[0],
-                                            absPath.length,
-                                            &absPath[prefix.length],
-                                            null /*filePartBuffer*/);
-
-        const foo = absPathRet > absPath.length ? null : absPath[0 .. absPathRet];
-        return absPathRet > absPath.length ? null : absPath[0 .. absPathRet];
-    }
-
-    // Converts a path to one suitable to be passed to Win32 API
-    // functions that can deal with paths longer than 248
-    // characters. For more information:
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
-    // buf is used as a scratch space instead of allocating. If its length is insufficient,
-    // memory is allocated on the GC heap.
-    package wchar[] toExtendedLengthPath(const(char*) path, wchar[] buf = []) nothrow
-    {
-        import core.sys.windows.winbase: GetFullPathNameW;
-
-        // Since the unicode Win32 APIs use UTF16, we need to convert
-        // from UTF8 to UTF16 first.
-        const wpath = path.toWStringz(buf);
+        const wpath = path.toWStringz(wpathBuf);
 
         // Now wpath is the UTF16 version of path, but to be able to use
         // extended paths, we need to prefix with `\\?\` and the absolute
@@ -828,9 +785,6 @@ version(Windows)
         // passing in so we defensively allocate 4 times the size of
         // the string we have currently.
         const absLength = prefix.length + wpath.length * 4;
-
-        // We now need a buffer `absLength` long. We try to reuse buf if there's
-        // enough space left. If not, allocate.
         static wchar[1024] absBuf;
         auto absPath = absLength > absBuf.length ? new wchar[absLength] : absBuf[];
 
@@ -841,8 +795,8 @@ version(Windows)
                                             &absPath[prefix.length],
                                             null /*filePartBuffer*/);
 
-        const foo = absPathRet > absPath.length ? null : absPath[0 .. absPathRet];
-        return absPathRet > absPath.length ? null : absPath[0 .. absPathRet];
+        auto extendedPath = absPathRet > absPath.length ? null : absPath[0 .. absPathRet];
+        return F(extendedPath);
     }
 
 

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -748,11 +748,9 @@ version(Windows)
         import core.sys.windows.winerror: ERROR_ALREADY_EXISTS;
         import core.stdc.errno: errno, EEXIST;
 
-        const extendedPath = path.toExtendedLengthPath();
+        wchar[2048] buf;
+        const extendedPath = path.toExtendedLengthPath(buf);
 
-        // the CreateDirectoryW function takes a pointer to a structure,
-        // but since we're not interested in using it it's declared void*
-        // and we pass null for the default behaviour.
         DWORD lastError;
         const createRet = () @trusted
         {

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -809,10 +809,9 @@ version(Windows)
                                             0 /*length8*/,
                                             null /*output buffer*/,
                                             null /*filePartBuffer*/);
-        const wchar[] emptyPath;
         if (pathLength == 0)
         {
-            return F(emptyPath);
+            return F(""w);
         }
 
         // wpath is the UTF16 version of path, but to be able to use
@@ -835,7 +834,7 @@ version(Windows)
 
         if (absPathRet == 0 || absPathRet > absPath.length - prefix.length)
         {
-            return F(emptyPath);
+            return F(""w);
         }
 
         auto extendedPath = absPath[0 .. absPathRet];

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -688,22 +688,24 @@ nothrow:
             DWORD length16 = GetFullPathNameW(&wpath[0], 0, null, null);
             if (length16)
             {
-                auto buf = cast(wchar*)malloc(length16);
-                length16 = GetFullPathNameW(&wpath[0], length16, buf, null);
+                auto buf = new wchar[length16];
+                length16 = GetFullPathNameW(&wpath[0], length16, &buf[0], null);
                 if (length16 == 0)
                 {
-                    .free(buf);
                     return null;
                 }
 
                 // allocate enough space for a UTF8 encoding of buf
-                const length8 = length16 * 4 + 1;
-                auto str = cast(char*)malloc(length8);
+                const length8 = length16 * 3 + 1;
+                auto str = new char[length8];
                 size_t strLen;
 
                 try
                     foreach(char c; buf[0 .. length16]) str[strLen++] = c;
-                catch(Exception _) {}
+                catch(Exception _)
+                {
+                    return null;
+                }
 
                 str[strLen] = 0; // null-terminate it
                 return &str[0];
@@ -831,7 +833,7 @@ version(Windows)
                                             &absPath[prefix.length],
                                             null /*filePartBuffer*/);
 
-        if (absPathRet == 0 || absPathRet > absPath.length)
+        if (absPathRet == 0 || absPathRet > absPath.length - prefix.length)
         {
             return F(emptyPath);
         }

--- a/src/ddmd/root/filename.d
+++ b/src/ddmd/root/filename.d
@@ -788,7 +788,7 @@ version(Windows)
 
         static immutable prefix = `\\?\`w; // see comment above
 
-        wchar[1024] absBuf;
+        static wchar[1024] absBuf;
 
         // We don't know how large the absolute file path will be We
         // need to tell GetFullPathName the size of the buffer we're

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -49,44 +49,6 @@ import ddmd.staticassert;
 import ddmd.tokens;
 import ddmd.visitor;
 
-/*******************************************
- * Check to see if statement is the innermost labeled statement.
- * Params:
- *      sc = context
- *      statement = Statement to check
- * Returns:
- *      if `true`, then the `LabelStatement`, otherwise `null`
- */
-extern (C++) LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
-{
-    if (sc.slabel && sc.slabel.statement == statement)
-    {
-        return sc.slabel;
-    }
-    return null;
-}
-
-/***********************************************************
- * Check an assignment is used as a condition.
- * Intended to be use before the `semantic` call on `e`.
- * Params:
- *  e = condition expression which is not yet run semantic analysis.
- * Returns:
- *  `e` or ErrorExp.
- */
-Expression checkAssignmentAsCondition(Expression e)
-{
-    auto ec = e;
-    while (ec.op == TOKcomma)
-        ec = (cast(CommaExp)ec).e2;
-    if (ec.op == TOKassign)
-    {
-        ec.error("assignment cannot be used as a condition, perhaps `==` was meant?");
-        return new ErrorExp();
-    }
-    return e;
-}
-
 /**
  * Returns:
  *     `TypeIdentifier` corresponding to `object.Throwable`

--- a/src/ddmd/statement.d
+++ b/src/ddmd/statement.d
@@ -49,31 +49,6 @@ import ddmd.staticassert;
 import ddmd.tokens;
 import ddmd.visitor;
 
-/*****************************************
- * CTFE requires FuncDeclaration::labtab for the interpretation.
- * So fixing the label name inside in/out contracts is necessary
- * for the uniqueness in labtab.
- * Params:
- *      sc = context
- *      ident = statement label name to be adjusted
- * Returns:
- *      adjusted label name
- */
-extern (C++) Identifier fixupLabelName(Scope* sc, Identifier ident)
-{
-    uint flags = (sc.flags & SCOPEcontract);
-    const id = ident.toChars();
-    if (flags && flags != SCOPEinvariant && !(id[0] == '_' && id[1] == '_'))
-    {
-        const(char)* prefix = flags == SCOPErequire ? "__in_" : "__out_";
-        OutBuffer buf;
-        buf.printf("%s%s", prefix, ident.toChars());
-
-        ident = Identifier.idPool(buf.peekSlice());
-    }
-    return ident;
-}
-
 /*******************************************
  * Check to see if statement is the innermost labeled statement.
  * Params:

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -97,6 +97,27 @@ private LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
     return null;
 }
 
+/***********************************************************
+ * Check an assignment is used as a condition.
+ * Intended to be use before the `semantic` call on `e`.
+ * Params:
+ *  e = condition expression which is not yet run semantic analysis.
+ * Returns:
+ *  `e` or ErrorExp.
+ */
+private Expression checkAssignmentAsCondition(Expression e)
+{
+    auto ec = e;
+    while (ec.op == TOKcomma)
+        ec = (cast(CommaExp)ec).e2;
+    if (ec.op == TOKassign)
+    {
+        ec.error("assignment cannot be used as a condition, perhaps `==` was meant?");
+        return new ErrorExp();
+    }
+    return e;
+}
+
 // Performs semantic analysis in Statement AST nodes
 extern(C++) Statement statementSemantic(Statement s, Scope* sc)
 {

--- a/src/ddmd/statementsem.d
+++ b/src/ddmd/statementsem.d
@@ -80,6 +80,23 @@ private Identifier fixupLabelName(Scope* sc, Identifier ident)
     return ident;
 }
 
+/*******************************************
+ * Check to see if statement is the innermost labeled statement.
+ * Params:
+ *      sc = context
+ *      statement = Statement to check
+ * Returns:
+ *      if `true`, then the `LabelStatement`, otherwise `null`
+ */
+private LabelStatement checkLabeledLoop(Scope* sc, Statement statement)
+{
+    if (sc.slabel && sc.slabel.statement == statement)
+    {
+        return sc.slabel;
+    }
+    return null;
+}
+
 // Performs semantic analysis in Statement AST nodes
 extern(C++) Statement statementSemantic(Statement s, Scope* sc)
 {

--- a/src/ddmd/utils.d
+++ b/src/ddmd/utils.d
@@ -92,7 +92,6 @@ extern (C++) void writeFile(Loc loc, File* f)
  */
 extern (C++) void ensurePathToNameExists(Loc loc, const(char)* name)
 {
-    import core.stdc.stdio;
     const(char)* pt = FileName.path(name);
     if (*pt)
     {

--- a/src/ddmd/utils.d
+++ b/src/ddmd/utils.d
@@ -92,6 +92,7 @@ extern (C++) void writeFile(Loc loc, File* f)
  */
 extern (C++) void ensurePathToNameExists(Loc loc, const(char)* name)
 {
+    import core.stdc.stdio;
     const(char)* pt = FileName.path(name);
     if (*pt)
     {

--- a/test/compilable/cppmangle.d
+++ b/test/compilable/cppmangle.d
@@ -379,9 +379,6 @@ else version (Posix)
 }
 
 /****************************************/
-// https://github.com/dlang/dmd/pull/6658
-// https://issues.dlang.org/show_bug.cgi?id=17947
-
 
 extern (C++, std)
 {
@@ -389,9 +386,49 @@ extern (C++, std)
     {
 	void swap(ref pair other);
     }
+
+    struct allocator(T)
+    {
+	uint fooa() const;
+	uint foob();
+    }
+
+    struct basic_string(T1, T2, T3)
+    {
+	uint fooa();
+    }
+
+    struct basic_istream(T1, T2)
+    {
+	uint fooc();
+    }
+
+    struct basic_ostream(T1, T2)
+    {
+	uint food();
+    }
+
+    struct basic_iostream(T1, T2)
+    {
+	uint fooe();
+    }
+
+    struct char_traits(T)
+    {
+	uint foof();
+    }
 }
 
 version (linux)
 {
+    // https://issues.dlang.org/show_bug.cgi?id=17947
     static assert(std.pair!(void*, void*).swap.mangleof == "_ZNSt4pairIPvS0_E4swapERS1_");
+
+    static assert(std.allocator!int.fooa.mangleof == "_ZNKSaIiE4fooaEv");
+    static assert(std.allocator!int.foob.mangleof == "_ZNSaIiE4foobEv");
+    static assert(std.basic_string!(char,int,uint).fooa.mangleof == "_ZNSbIcijE4fooaEv");
+    static assert(std.basic_string!(char, std.char_traits!char, std.allocator!char).fooa.mangleof == "_ZNSs4fooaEv");
+    static assert(std.basic_istream!(char, std.char_traits!char).fooc.mangleof == "_ZNSi4foocEv");
+    static assert(std.basic_ostream!(char, std.char_traits!char).food.mangleof == "_ZNSo4foodEv");
+    static assert(std.basic_iostream!(char, std.char_traits!char).fooe.mangleof == "_ZNSd4fooeEv");
 }

--- a/test/compilable/extra-files/json.out
+++ b/test/compilable/extra-files/json.out
@@ -231,7 +231,7 @@
       "kind" : "variable",
       "protection" : "private",
       "line" : 32,
-      "char" : 14,
+      "char" : 17,
       "deco" : "i",
       "offset" : 32
      },
@@ -279,7 +279,7 @@
       "name" : "bar2",
       "kind" : "variable",
       "line" : 39,
-      "char" : 7,
+      "char" : 10,
       "deco" : "C4json4Bar2",
       "originalType" : "Bar2",
       "offset" : 0
@@ -288,13 +288,13 @@
       "name" : "U",
       "kind" : "union",
       "line" : 40,
-      "char" : 2,
+      "char" : 5,
       "members" : [
        {
         "name" : "s",
         "kind" : "variable",
         "line" : 42,
-        "char" : 10,
+        "char" : 19,
         "deco" : "s",
         "offset" : 0
        },
@@ -302,7 +302,7 @@
         "name" : "i",
         "kind" : "variable",
         "line" : 43,
-        "char" : 8,
+        "char" : 17,
         "deco" : "i",
         "offset" : 4
        },
@@ -310,7 +310,7 @@
         "name" : "o",
         "kind" : "variable",
         "line" : 45,
-        "char" : 10,
+        "char" : 16,
         "deco" : "C6Object",
         "originalType" : "Object",
         "offset" : 0
@@ -320,9 +320,53 @@
     ]
    },
    {
+    "kind" : "template",
+    "line" : 49,
+    "char" : 1,
+    "name" : "Foo3",
+    "parameters" : [
+     {
+      "name" : "b",
+      "kind" : "value",
+      "deco" : "b"
+     }
+    ],
+    "members" : [
+     {
+      "name" : "Foo3",
+      "kind" : "struct",
+      "line" : 49,
+      "char" : 1,
+      "members" : [
+       {
+        "name" : "method1",
+        "kind" : "function",
+        "line" : 52,
+        "char" : 14,
+        "type" : "void()"
+       },
+       {
+        "name" : "method2",
+        "kind" : "function",
+        "line" : 56,
+        "char" : 14,
+        "type" : "void()"
+       },
+       {
+        "name" : "method4",
+        "kind" : "function",
+        "line" : 63,
+        "char" : 10,
+        "type" : "void()"
+       }
+      ]
+     }
+    ]
+   },
+   {
     "name" : "bar",
     "kind" : "function",
-    "line" : 52,
+    "line" : 69,
     "char" : 16,
     "deco" : "FNeKkC4json4Bar2Zi",
     "originalType" : "@trusted myInt(ref uint blah, Bar2 foo = new Bar3(7))",
@@ -340,22 +384,22 @@
       "default" : "new Bar3(7)"
      }
     ],
-    "endline" : 55,
+    "endline" : 72,
     "endchar" : 1
    },
    {
     "name" : "outer",
     "kind" : "function",
-    "line" : 57,
+    "line" : 74,
     "char" : 15,
     "deco" : "FNbNdZi",
-    "endline" : 74,
+    "endline" : 91,
     "endchar" : 1
    },
    {
     "name" : "imports.jsonimport1",
     "kind" : "import",
-    "line" : 77,
+    "line" : 94,
     "char" : 8,
     "protection" : "private",
     "selective" : [
@@ -366,7 +410,7 @@
    {
     "name" : "imports.jsonimport2",
     "kind" : "import",
-    "line" : 78,
+    "line" : 95,
     "char" : 8,
     "protection" : "private",
     "renamed" : {
@@ -377,7 +421,7 @@
    {
     "name" : "imports.jsonimport3",
     "kind" : "import",
-    "line" : 79,
+    "line" : 96,
     "char" : 8,
     "protection" : "private",
     "renamed" : {
@@ -391,19 +435,19 @@
    {
     "name" : "imports.jsonimport4",
     "kind" : "import",
-    "line" : 80,
+    "line" : 97,
     "char" : 8,
     "protection" : "private"
    },
    {
     "name" : "S",
     "kind" : "struct",
-    "line" : 82,
+    "line" : 99,
     "char" : 1,
     "members" : [
      {
       "kind" : "template",
-      "line" : 85,
+      "line" : 102,
       "char" : 5,
       "name" : "this",
       "parameters" : [
@@ -416,7 +460,7 @@
        {
         "name" : "this",
         "kind" : "constructor",
-        "line" : 85,
+        "line" : 102,
         "char" : 5,
         "type" : "(T t)",
         "parameters" : [
@@ -425,7 +469,7 @@
           "type" : "T"
          }
         ],
-        "endline" : 85,
+        "endline" : 102,
         "endchar" : 20
        }
       ]
@@ -435,7 +479,7 @@
    {
     "kind" : "template",
     "protection" : "private",
-    "line" : 89,
+    "line" : 106,
     "char" : 9,
     "name" : "S1_9755",
     "parameters" : [
@@ -448,7 +492,7 @@
      {
       "name" : "S1_9755",
       "kind" : "struct",
-      "line" : 89,
+      "line" : 106,
       "char" : 9,
       "members" : []
      }
@@ -457,7 +501,7 @@
    {
     "kind" : "template",
     "protection" : "package",
-    "line" : 90,
+    "line" : 107,
     "char" : 9,
     "name" : "S2_9755",
     "parameters" : [
@@ -470,7 +514,7 @@
      {
       "name" : "S2_9755",
       "kind" : "struct",
-      "line" : 90,
+      "line" : 107,
       "char" : 9,
       "members" : []
      }
@@ -479,13 +523,13 @@
    {
     "name" : "C_9755",
     "kind" : "class",
-    "line" : 92,
+    "line" : 109,
     "char" : 1,
     "members" : [
      {
       "kind" : "template",
       "protection" : "protected",
-      "line" : 94,
+      "line" : 111,
       "char" : 22,
       "name" : "CI_9755",
       "parameters" : [
@@ -498,7 +542,7 @@
        {
         "name" : "CI_9755",
         "kind" : "class",
-        "line" : 94,
+        "line" : 111,
         "char" : 22,
         "members" : []
        }
@@ -509,7 +553,7 @@
    {
     "name" : "c_10011",
     "kind" : "variable",
-    "line" : 98,
+    "line" : 115,
     "char" : 14,
     "storageClass" : [
      "const"
@@ -521,7 +565,7 @@
    {
     "name" : "Numbers",
     "kind" : "enum",
-    "line" : 101,
+    "line" : 118,
     "char" : 1,
     "baseDeco" : "i",
     "members" : [
@@ -529,56 +573,56 @@
       "name" : "unspecified1",
       "kind" : "enum member",
       "value" : "0",
-      "line" : 103,
+      "line" : 120,
       "char" : 5
      },
      {
       "name" : "one",
       "kind" : "enum member",
       "value" : "2",
-      "line" : 104,
+      "line" : 121,
       "char" : 5
      },
      {
       "name" : "two",
       "kind" : "enum member",
       "value" : "3",
-      "line" : 105,
+      "line" : 122,
       "char" : 5
      },
      {
       "name" : "FILE_NOT_FOUND",
       "kind" : "enum member",
       "value" : "101",
-      "line" : 106,
+      "line" : 123,
       "char" : 5
      },
      {
       "name" : "unspecified3",
       "kind" : "enum member",
       "value" : "102",
-      "line" : 107,
+      "line" : 124,
       "char" : 5
      },
      {
       "name" : "unspecified4",
       "kind" : "enum member",
       "value" : "103",
-      "line" : 108,
+      "line" : 125,
       "char" : 5
      },
      {
       "name" : "four",
       "kind" : "enum member",
       "value" : "4",
-      "line" : 109,
+      "line" : 126,
       "char" : 5
      }
     ]
    },
    {
     "kind" : "template",
-    "line" : 112,
+    "line" : 129,
     "char" : 1,
     "name" : "IncludeConstraint",
     "parameters" : [
@@ -593,8 +637,8 @@
    {
     "name" : "a0",
     "kind" : "variable",
-    "file" : "compilable/json.d-mixin-116",
-    "line" : 116,
+    "file" : "compilable/json.d-mixin-133",
+    "line" : 133,
     "char" : 5,
     "deco" : "i",
     "init" : "1"
@@ -602,7 +646,7 @@
    {
     "name" : "a1",
     "kind" : "variable",
-    "line" : 116,
+    "line" : 133,
     "char" : 5,
     "deco" : "i",
     "init" : "1"
@@ -610,7 +654,7 @@
    {
     "name" : "a2",
     "kind" : "variable",
-    "line" : 116,
+    "line" : 133,
     "char" : 5,
     "deco" : "i",
     "init" : "1"
@@ -618,7 +662,7 @@
    {
     "kind" : "template",
     "file" : "compilable/json.d",
-    "line" : 119,
+    "line" : 136,
     "char" : 1,
     "name" : "Seq",
     "parameters" : [
@@ -631,7 +675,7 @@
      {
       "name" : "Seq",
       "kind" : "alias",
-      "line" : 119,
+      "line" : 136,
       "char" : 1,
       "type" : "T"
      }
@@ -641,29 +685,29 @@
    {
     "name" : "b0",
     "kind" : "alias",
-    "file" : "compilable/json.d-mixin-123",
-    "line" : 123,
+    "file" : "compilable/json.d-mixin-140",
+    "line" : 140,
     "char" : 1
    },
    {},
    {
     "name" : "b1",
     "kind" : "alias",
-    "line" : 123,
+    "line" : 140,
     "char" : 1
    },
    {},
    {
     "name" : "b2",
     "kind" : "alias",
-    "line" : 123,
+    "line" : 140,
     "char" : 1
    },
    {
     "name" : "foo",
     "kind" : "function",
     "file" : "compilable/json.d",
-    "line" : 127,
+    "line" : 144,
     "char" : 9,
     "deco" : "FNcNfNkKiZi",
     "parameters" : [
@@ -676,13 +720,13 @@
       ]
      }
     ],
-    "endline" : 130,
+    "endline" : 147,
     "endchar" : 1
    },
    {
     "name" : "foo",
     "kind" : "function",
-    "line" : 132,
+    "line" : 149,
     "char" : 6,
     "deco" : "FNfMNkPiZQd",
     "parameters" : [
@@ -695,13 +739,13 @@
       ]
      }
     ],
-    "endline" : 135,
+    "endline" : 152,
     "endchar" : 1
    },
    {
     "name" : "foo",
     "kind" : "function",
-    "line" : 137,
+    "line" : 154,
     "char" : 10,
     "deco" : "FNcNfMNkKPiZQd",
     "parameters" : [
@@ -715,46 +759,46 @@
       ]
      }
     ],
-    "endline" : 140,
+    "endline" : 157,
     "endchar" : 1
    },
    {
     "name" : "SafeS",
     "kind" : "struct",
-    "line" : 142,
+    "line" : 159,
     "char" : 1,
     "members" : [
      {
       "name" : "foo",
       "kind" : "function",
-      "line" : 145,
+      "line" : 162,
       "char" : 12,
       "deco" : "FNcNjNfZS4json5SafeS",
-      "endline" : 148,
+      "endline" : 165,
       "endchar" : 2
      },
      {
       "name" : "foo",
       "kind" : "function",
-      "line" : 150,
+      "line" : 167,
       "char" : 8,
       "deco" : "FNjNfZS4json5SafeS",
-      "endline" : 153,
+      "endline" : 170,
       "endchar" : 2
      },
      {
       "name" : "foo",
       "kind" : "function",
-      "line" : 155,
+      "line" : 172,
       "char" : 12,
       "deco" : "FNcNjNfZS4json5SafeS",
-      "endline" : 158,
+      "endline" : 175,
       "endchar" : 2
      },
      {
       "name" : "p",
       "kind" : "variable",
-      "line" : 160,
+      "line" : 177,
       "char" : 7,
       "storageClass" : [
        "@safe"

--- a/test/compilable/json.d
+++ b/test/compilable/json.d
@@ -29,21 +29,38 @@ class Bar2 : Bar!1, Baz!(int, 2, null) {
 }
 
 class Bar3 : Bar2 {
-	private int val;
+    private int val;
     this(int i) { val = i; }
 
     protected override Foo!int baz() { return Foo!int(val); }
 }
 
 struct Foo2 {
-	Bar2 bar2;
-	union U {
-		struct {
-			short s;
-			int i;
-		}
-		Object o;
-	}
+    Bar2 bar2;
+    union U {
+        struct {
+            short s;
+            int i;
+        }
+        Object o;
+    }
+}
+
+struct Foo3(bool b) {
+    version(D_Ddoc) {
+        /// Doc 1
+        void method1();
+    }
+    static if (b) {
+        /// Doc 2
+        void method2();
+    } else {
+        /// Doc 3
+        void method3();
+    }
+
+    /// Doc 4
+    void method4();
 }
 
 /++
@@ -51,26 +68,26 @@ struct Foo2 {
  +/
 @trusted myInt bar(ref uint blah, Bar2 foo = new Bar3(7)) // bug 4477
 {
-	return -1;
+    return -1;
 }
 
 @property int outer() nothrow
 in {
-	assert(true);
+    assert(true);
 }
 out(result) {
-	assert(result == 18);
+    assert(result == 18);
 }
 body {
-	int x = 8;
-	int inner(void* v) nothrow
-	{
-		int y = 2;
-		assert(true);
-		return x + y;
-	}
-	int z = inner(null);
-	return x + z;
+    int x = 8;
+    int inner(void* v) nothrow
+    {
+        int y = 2;
+        assert(true);
+        return x + y;
+    }
+    int z = inner(null);
+    return x + z;
 }
 
 /** Issue 9484 - selective and renamed imports */


### PR DESCRIPTION
dub uses relative paths when compiling dependent dub packages, which sometimes result in file paths that are too long for `mkdir` on Windows. This patch fixes the issue by using the newer unicode Win32 path APIs to create directories and files in dmd.