### PR TITLE
Enable 64-bit build with VC2015

### DIFF
--- a/src/ddmd/backend/gflow.c
+++ b/src/ddmd/backend/gflow.c
@@ -323,7 +323,7 @@ STATIC void accumrd(vec_t GEN,vec_t KILL,elem *n)
                 rdelem(&Gl,&Kl,n->E1);
                 rdelem(&Gr,&Kr,n->E2);
 
-                switch (el_returns(n->E1) * 2 | el_returns(n->E2))
+                switch (el_returns(n->E1) * 2 | int(el_returns(n->E2)))
                 {
                     case 3: // E1 and E2 return
                         /* GEN = (GEN - Kl) | Gl |

--- a/src/ddmd/backend/gloop.c
+++ b/src/ddmd/backend/gloop.c
@@ -1034,7 +1034,7 @@ STATIC void markinvar(elem *n,vec_t rd)
         case OPcolon:
         case OPcolon2:
                 tmp = vec_clone(rd);
-                switch (el_returns(n->E1) * 2 | el_returns(n->E2))
+                switch (int(el_returns(n->E1) * 2) | int(el_returns(n->E2)))
                 {
                     case 3: // E1 and E2 return
                         markinvar(n->E1,rd);

--- a/src/ddmd/backend/gother.c
+++ b/src/ddmd/backend/gother.c
@@ -219,7 +219,7 @@ STATIC void conpropwalk(elem *n,vec_t IN)
         if (op == OPcolon || op == OPcolon2)
         {
                 L = vec_clone(IN);
-                switch (el_returns(n->E1) * 2 | el_returns(n->E2))
+                switch (int(el_returns(n->E1) * 2) | int(el_returns(n->E2)))
                 {
                     case 3: // E1 and E2 return
                         conpropwalk(n->E1,L);

--- a/src/vcbuild/msvc-dmc.d
+++ b/src/vcbuild/msvc-dmc.d
@@ -11,6 +11,8 @@ import std.stdio;
 
 int main(string[] args)
 {
+    import std.algorithm: canFind;
+
     auto cl = environment.get("MSVC_CC",
         environment.get("VCINSTALLDIR", `\Program Files (x86)\Microsoft Visual Studio 10.0\VC\`)
             .buildPath("bin", "amd64", "cl.exe"));
@@ -19,6 +21,15 @@ int main(string[] args)
     newArgs ~= `/Ivcbuild`;
     newArgs ~= `/Iddmd\root`;
     newArgs ~= `/FIwarnings.h`;
+
+    enum vs2015 = "Microsoft Visual Studio 14.0";
+    if (environment.get("VCINSTALLDIR", "").canFind(vs2015) || environment.get("MSVC_CC", "").canFind(vs2015))
+    {
+        // either this or /EHsc due to 'noexcept' in system headers
+        newArgs ~= `/D_HAS_EXCEPTIONS=0`;
+        // disable narrowing conversion warnings
+        newArgs ~= `/Wv:18`;
+    }
     bool compilingOnly;
 
     foreach (arg; args[1..$])

--- a/win64.mak
+++ b/win64.mak
@@ -1,0 +1,10 @@
+# To be able to use this Makefile Visual Studio must be installed.
+# If the VC version is not 10.0, then the environment variable VCINSTALLDIR must be set
+# to the directory where it is installed (e.g. C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\).
+# The corresponding vcvarsall.bat must also be called (e.g. call C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat amd64)
+
+MAKE=make
+
+all:
+	cd src
+	$(MAKE) -f win64.mak


### PR DESCRIPTION
The newer compiler emits some warnings that are treated as errors. This PR also includes a top-level win64.mak for easier builds.